### PR TITLE
Add GitHub Action for AI-ML SDK checkout and sync

### DIFF
--- a/.github/actions/checkout/README.md
+++ b/.github/actions/checkout/README.md
@@ -1,0 +1,113 @@
+# AI‑ML SDK Checkout Action
+
+Composite GitHub Action to **checkout and sync the Arm AI‑ML SDK** repositories
+
+---
+
+## Why this action?
+- One step to grab the whole AI‑ML SDK stack from the manifest
+- Cross‑platform: Ubuntu, macOS, Windows
+- Optional per‑group checkout to reduce sync time
+- Built‑in, declarative overrides for reproducible builds
+
+---
+
+## Quick start
+Add this job step to your workflow:
+
+```yaml
+jobs:
+  checkout_sdk:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout AI‑ML SDK
+        uses: arm/ai-ml-sdk-manifest@main
+        with:
+          repo_groups: all
+          overrides: |
+            # One per line: owner/repo@ref
+            arm/ai-ml-sdk-model-converter@v1.2.3
+            myorg/ai-ml-sdk-scenario-runner@feature/x
+```
+
+## Inputs
+
+### `repo_groups`
+Which repo group to initialize via `repo init -g`.
+
+Allowed values: `all`, `model-converter`, `scenario-runner`, `emulation-layer`, `vgf-lib`
+
+Default: `all`
+
+### `overrides`
+Multiline string. Optional **one‑per‑line** overrides in the form:
+
+```
+owner/repo@ref
+```
+
+- `owner/repo` must be one of the recognized repositories (see below).
+- `ref` may be a branch name, tag, or full/short commit SHA. If omitted, `main` is used.
+- Inline comments are allowed using `#` (everything after `#` on a line is ignored).
+- Blank lines are ignored.
+
+Examples:
+
+```
+# Pin two repos to specific refs
+arm/ai-ml-sdk-model-converter@v1.2.3
+alice/ai-ml-sdk-scenario-runner@feature/x
+
+# Use an exact commit
+arm/ai-ml-sdk-vgf-library@abcd1234
+```
+
+**Recognized repositories** (and where they live in the workspace):
+
+| Repository slug                         | Path in workspace        |
+|-----------------------------------------|--------------------------|
+| `ai-ml-sdk-for-vulkan`                  | `.`                      |
+| `ai-ml-sdk-model-converter`             | `sw/model-converter`     |
+| `ai-ml-sdk-scenario-runner`             | `sw/scenario-runner`     |
+| `ai-ml-sdk-vgf-library`                 | `sw/vgf-lib`             |
+| `ai-ml-emulation-layer-for-vulkan`      | `sw/emulation-layer`     |
+
+> Note: If a path is missing after sync, it may be filtered out by the chosen `repo_groups`.
+
+---
+
+## Usage patterns
+
+### Minimal (defaults)
+```yaml
+- name: Checkout AI‑ML SDK (defaults)
+  uses: arm/ai-ml-sdk-manifest@main
+```
+
+### Only the model converter group
+```yaml
+- name: Checkout model converter
+  uses: arm/ai-ml-sdk-manifest@main
+  with:
+    repo_groups: model-converter
+```
+
+### Pin specific repos using overrides
+```yaml
+- name: Checkout with overrides
+  uses: arm/ai-ml-sdk-manifest@main
+  with:
+    overrides: |
+      arm/ai-ml-sdk-model-converter@v1.2.3
+      myorg/ai-ml-sdk-scenario-runner@feature/x
+```
+
+---
+
+## License
+
+```
+SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited
+SPDX-License-Identifier: Apache-2.0
+```
+

--- a/.github/actions/checkout/action.yml
+++ b/.github/actions/checkout/action.yml
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+name: Checkout
+description: Checkout and sync all the ai ml sdk
+
+inputs:
+  repo_groups:
+    description: "Group for 'repo init -g' (all | model-converter | scenario-runner | emulation-layer | vgf-lib)"
+    required: false
+    default: all
+
+  overrides:
+    description: |
+      Optional overrides, one per line, format: owner/repo@ref
+      Examples:
+        myorg/ai-ml-sdk-for-vulkan@abcd1234
+        alice/ai-ml-sdk-scenario-runner@feature/x
+        arm/ai-ml-sdk-vgf-library@4063e1626aa14771816d5bf49c14230b40e66658
+      Notes:
+        - Only the following repos are recognized: ai-ml-sdk-for-vulkan, ai-ml-sdk-model-converter, ai-ml-sdk-scenario-runner, ai-ml-sdk-vgf-library, ai-ml-emulation-layer-for-vulkan
+        - Omit this input to use manifest defaults (no overrides applied).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Python 3.11
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Enable long paths and download repo (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        Set-StrictMode -Version Latest
+        Set-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1
+        git config --global core.longpaths true
+        $repoDir = "$HOME\.bin\git-repo"
+        $repoBin = "$repoDir\repo"
+        New-Item -ItemType Directory -Force -Path $repoDir | Out-Null
+        curl.exe -fL --retry 3 --retry-delay 3 "https://storage.googleapis.com/git-repo-downloads/repo" -o $repoBin
+
+    - name: Download repo tool (macOS/Linux)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p "$HOME/.bin/git-repo"
+        curl -fL --retry 3 --retry-delay 3 https://storage.googleapis.com/git-repo-downloads/repo -o "$HOME/.bin/git-repo/repo"
+        chmod +x "$HOME/.bin/git-repo/repo"
+
+    - name: repo init (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        Set-StrictMode -Version Latest
+        $valid = @('all','model-converter','scenario-runner','emulation-layer','vgf-lib')
+        $grp = '${{ inputs.repo_groups }}'
+        if ($valid -notcontains $grp) {
+          Write-Error "Invalid repo_groups: $grp. Allowed: $($valid -join ', ')"
+          exit 2
+        }
+        python "$HOME\.bin\git-repo\repo" init -u https://github.com/arm/ai-ml-sdk-manifest.git --depth=1 -g $grp
+
+    - name: repo init (macOS/Linux)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+        case "${{ inputs.repo_groups }}" in
+          all|model-converter|scenario-runner|emulation-layer|vgf-lib) ;;
+          *) echo "Invalid repo_groups: ${{ inputs.repo_groups }}. Allowed: all, model-converter, scenario-runner, emulation-layer, vgf-lib" >&2; exit 2;;
+        esac
+        python "$HOME/.bin/git-repo/repo" init -u https://github.com/arm/ai-ml-sdk-manifest.git --depth=1 -g "${{ inputs.repo_groups }}"
+
+    - name: repo sync (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = "Stop"
+        Set-StrictMode -Version Latest
+        python "$HOME\.bin\git-repo\repo" sync
+
+    - name: repo sync (macOS/Linux)
+      if: runner.os != 'Windows'
+      shell: bash
+      run: |
+        set -euo pipefail
+        python "$HOME/.bin/git-repo/repo" sync
+
+    - name: Apply overrides (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        OVERRIDES: ${{ inputs.overrides }}
+      run: |
+        $ErrorActionPreference = "Stop"
+        Set-StrictMode -Version Latest
+        python "$env:GITHUB_ACTION_PATH\apply_overrides.py"
+
+    - name: Apply overrides (macOS/Linux)
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        OVERRIDES: ${{ inputs.overrides }}
+      run: |
+        set -euo pipefail
+        python "$GITHUB_ACTION_PATH/apply_overrides.py"

--- a/.github/actions/checkout/apply_overrides.py
+++ b/.github/actions/checkout/apply_overrides.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import pathlib
+import re
+import shlex
+import subprocess
+import sys
+
+REPO_DIRS = {
+    "ai-ml-sdk-for-vulkan": ".",
+    "ai-ml-sdk-model-converter": "sw/model-converter",
+    "ai-ml-sdk-scenario-runner": "sw/scenario-runner",
+    "ai-ml-sdk-vgf-library": "sw/vgf-lib",
+    "ai-ml-emulation-layer-for-vulkan": "sw/emulation-layer",
+}
+
+
+def run(cmd, cwd):
+    print("+", " ".join(shlex.quote(x) for x in cmd))
+    p = subprocess.run(cmd,
+                       cwd=cwd,
+                       stdout=subprocess.PIPE,
+                       stderr=subprocess.STDOUT,
+                       text=True)
+    if p.stdout:
+        sys.stdout.write(p.stdout)
+    return p.returncode, p.stdout or ""
+
+
+def check_call(cmd, cwd):
+    print("+", " ".join(shlex.quote(x) for x in cmd))
+    subprocess.check_call(cmd, cwd=cwd)
+
+
+def ensure_override_remote(dir_path: pathlib.Path, url: str) -> None:
+    check_call(["git", "remote", "add", "override", url], cwd=dir_path)
+
+
+def resolve_ref(dir_path: pathlib.Path, ref: str) -> str | None:
+    code, _ = run([
+        "git", "rev-parse", "--verify", "--quiet",
+        f"refs/remotes/override/{ref}"
+    ],
+                  cwd=dir_path)
+    if code == 0:
+        return f"override/{ref}"
+    code, _ = run(
+        ["git", "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+        cwd=dir_path)
+    if code == 0:
+        return ref
+    return None
+
+
+def apply_override(owner, repo, ref):
+    if repo not in REPO_DIRS:
+        print(f"Skip {owner}/{repo}@{ref}: unrecognized repo")
+        return
+
+    dir_path = pathlib.Path(REPO_DIRS[repo])
+    if not dir_path.exists():
+        print(
+            f"Skip {repo}: path not found '{dir_path}' (possibly filtered by repo_groups)"
+        )
+        return
+    if not (dir_path / ".git").exists():
+        print(f"Not a git repo at '{dir_path}'", file=sys.stderr)
+        sys.exit(1)
+
+    url = f"https://github.com/{owner}/{repo}.git"
+    ensure_override_remote(dir_path, url)
+    check_call(["git", "fetch", "--tags", "--force", "override"], cwd=dir_path)
+
+    target = resolve_ref(dir_path, ref)
+    if target is None:
+        print(f"Ref not found for {repo}: '{ref}'", file=sys.stderr)
+        _code, _out = run(["git", "show-ref", "--heads", "--tags"],
+                          cwd=dir_path)
+        sys.exit(2)
+
+    check_call(["git", "reset", "--hard", target], cwd=dir_path)
+    print(f"Override applied to {repo} at '{dir_path}' -> {target}")
+
+
+_SPEC_RE = re.compile(
+    r'^\s*(?P<owner>[A-Za-z0-9_.-]+)/(?P<repo>[A-Za-z0-9_.-]+)(?:@(?P<ref>[^#\s]+))?\s*$'
+)
+
+
+def parse_and_apply(overrides_text: str) -> None:
+    text = overrides_text or ""
+    parsed_specs: list[tuple[str, str, str, int]] = []
+
+    for line_no, raw in enumerate(text.splitlines(), 1):
+        original = raw
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # strip inline comments: owner/repo@ref # note
+        if "#" in line:
+            line = line.split("#", 1)[0].strip()
+            if not line:
+                continue
+        m = _SPEC_RE.match(line)
+        if not m:
+            print(f"Skip invalid override on line {line_no}: '{original}'")
+            continue
+        owner = m.group("owner")
+        repo = m.group("repo")
+        ref = m.group("ref") or "main"
+        if repo not in REPO_DIRS:
+            print(f"Skip unknown repo on line {line_no}: '{repo}'")
+            continue
+        parsed_specs.append((owner, repo, ref, line_no))
+
+    if not parsed_specs:
+        print("No valid overrides provided. Skipping.")
+        return
+
+    for idx, (owner, repo, ref, line_no) in enumerate(parsed_specs):
+        apply_override(owner, repo, ref)
+
+
+if __name__ == "__main__":
+    parse_and_apply(os.environ.get("OVERRIDES", ""))

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
+# SPDX-License-Identifier: Apache-2.0
+name: Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      ai-ml-sdk-model-converter_owner:
+        description: Owner/org for ai-ml-sdk-model-converter
+        default: arm
+        required: false
+      ai-ml-sdk-model-converter_revision:
+        description: Revision for arm/ai-ml-sdk-model-converter
+        default: main
+        required: false
+      ai-ml-sdk-scenario-runner_owner:
+        description: Owner/org for ai-ml-sdk-scenario-runner
+        default: arm
+        required: false
+      ai-ml-sdk-scenario-runner_revision:
+        description: Revision for arm/ai-ml-sdk-scenario-runner
+        default: main
+        required: false
+      ai-ml-sdk-vgf-library_owner:
+        description: Owner/org for ai-ml-sdk-vgf-library
+        default: arm
+        required: false
+      ai-ml-sdk-vgf-library_revision:
+        description: Revision for arm/ai-ml-sdk-vgf-library
+        default: main
+        required: false
+      ai-ml-emulation-layer-for-vulkan_owner:
+        description: Owner/org for ai-ml-emulation-layer-for-vulkan
+        default: arm
+        required: false
+      ai-ml-emulation-layer-for-vulkan_revision:
+        description: Revision for arm/ai-ml-emulation-layer-for-vulkan
+        default: main
+        required: false
+      ai-ml-sdk-for-vulkan_owner:
+        description: Owner/org for ai-ml-sdk-for-vulkan
+        default: arm
+        required: false
+      ai-ml-sdk-for-vulkan_revision:
+        description: Revision for arm/ai-ml-sdk-for-vulkan
+        default: main
+        required: false
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 3 * * *' # Nightly at 03:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-15
+          - windows-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          path: ./manifest
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Checkout and sync repos
+        uses: ./manifest/.github/actions/checkout
+        with:
+          overrides: |
+            ${{ github.event.inputs.ai-ml-sdk-model-converter_owner || 'arm' }}/ai-ml-sdk-model-converter@${{ github.event.inputs.ai-ml-sdk-model-converter_revision || 'main' }}
+            ${{ github.event.inputs.ai-ml-sdk-scenario-runner_owner || 'arm' }}/ai-ml-sdk-scenario-runner@${{ github.event.inputs.ai-ml-sdk-scenario-runner_revision || 'main' }}
+            ${{ github.event.inputs.ai-ml-sdk-vgf-library_owner || 'arm' }}/ai-ml-sdk-vgf-library@${{ github.event.inputs.ai-ml-sdk-vgf-library_revision || 'main' }}
+            ${{ github.event.inputs.ai-ml-emulation-layer-for-vulkan_owner || 'arm' }}/ai-ml-emulation-layer-for-vulkan@${{ github.event.inputs.ai-ml-emulation-layer-for-vulkan_revision || 'main' }}
+            ${{ github.event.inputs.ai-ml-sdk-for-vulkan_owner || 'arm' }}/ai-ml-sdk-for-vulkan@${{ github.event.inputs.ai-ml-sdk-for-vulkan_revision || 'main' }}
+
+      - name: Build (macOS/Linux)
+        if: runner.os != 'Windows'
+        run: ./scripts/build.py
+
+      - name: Build (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          python scripts\build.py


### PR DESCRIPTION
## `checkout` action  

This PR introduces a new GitHub Action that initializes and synchronizes the AI/ML SDK across Windows, macOS, and Linux in a simple way.  
The goal is to reuse the code across all repositories, allowing developers to quickly check out only what they need and overwrite with new code for fast testing.  

## Build workflow  

The `checkout` action is used to build the full SDK and also supports manually triggering builds on forked repositories.  
Example log: [GitHub Actions Run](https://github.com/Chizkiyahu/ai-ml-sdk-manifest/actions/runs/17407602128)  
